### PR TITLE
Issue/989 add zstandard support

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -75,6 +75,13 @@ func GetControlFileFromDeb(packageFile string) (Stanza, error) {
 				}
 				defer unxz.Close()
 				tarInput = unxz
+			case "control.tar.zst":
+				unzstd, err := zstd.NewReader(bufReader)
+				if err != nil {
+					return nil, errors.Wrapf(err, "unable to unzstd data.tar.zstd from %s", packageFile)
+				}
+				defer unzstd.Close()
+				tarInput = unzstd
 			default:
 				return nil, fmt.Errorf("unsupported tar compression in %s: %s", packageFile, header.Name)
 			}

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/aptly-dev/aptly/pgp"
 	"github.com/kjk/lzma"
+	"github.com/klauspost/compress/zstd"
 	"github.com/smira/go-xz"
 )
 
@@ -189,6 +190,13 @@ func GetContentsFromDeb(file io.Reader, packageFile string) ([]string, error) {
 				unlzma := lzma.NewReader(bufReader)
 				defer unlzma.Close()
 				tarInput = unlzma
+			case "data.tar.zst":
+				unzstd, err := zstd.NewReader(bufReader)
+				if err != nil {
+					return nil, errors.Wrapf(err, "unable to unzstd data.tar.zstd from %s", packageFile)
+				}
+				defer unzstd.Close()
+				tarInput = unzstd
 			default:
 				return nil, fmt.Errorf("unsupported tar compression in %s: %s", packageFile, header.Name)
 			}

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -78,7 +78,7 @@ func GetControlFileFromDeb(packageFile string) (Stanza, error) {
 			case "control.tar.zst":
 				unzstd, err := zstd.NewReader(bufReader)
 				if err != nil {
-					return nil, errors.Wrapf(err, "unable to unzstd data.tar.zstd from %s", packageFile)
+					return nil, errors.Wrapf(err, "unable to unzstd %s from %s", header.Name, packageFile)
 				}
 				defer unzstd.Close()
 				tarInput = unzstd
@@ -200,7 +200,7 @@ func GetContentsFromDeb(file io.Reader, packageFile string) ([]string, error) {
 			case "data.tar.zst":
 				unzstd, err := zstd.NewReader(bufReader)
 				if err != nil {
-					return nil, errors.Wrapf(err, "unable to unzstd data.tar.zstd from %s", packageFile)
+					return nil, errors.Wrapf(err, "unable to unzstd %s from %s", header.Name, packageFile)
 				}
 				defer unzstd.Close()
 				tarInput = unzstd

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/h2non/filetype v1.0.5
 	github.com/jlaffaye/ftp v0.0.0-20180404123514-2403248fa8cc // indirect
 	github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d
+	github.com/klauspost/compress v1.13.6
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-runewidth v0.0.2 // indirect
 	github.com/mattn/go-shellwords v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d h1:RnWZeH8N8KXfbwMTex/KKMYMj0FJRCF6tQubUuQ02GM=
 github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d/go.mod h1:phT/jsRPBAEqjAibu1BurrabCBNTYiVI+zbmyCZJY6Q=
+github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
+github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=


### PR DESCRIPTION
This is a copy of the changes in https://github.com/aptly-dev/aptly/pull/1002 (rebased on master) to be merged into the Yelp fork of aptly along with other changes so we can streamline changes to aptly from different contributors and build them internally.

-- 
Update. 
I've actually made a small change to the original branch: I removed this commit https://github.com/ahaswell/aptly/commit/e22b1289d89a4fa7732c4a25f66e8e12fd2dc8e2 from it as I don't think it is needed (those lines in go.sum gets removed when I run `go mod tidy`)