### PR TITLE
Use the newer recommended S3 ListObjectsV2 API

### DIFF
--- a/s3/public.go
+++ b/s3/public.go
@@ -372,13 +372,13 @@ func (storage *PublishedStorage) internalFilelist(prefix string, hidePlusWorkaro
 		prefix += "/"
 	}
 
-	params := &s3.ListObjectsInput{
+	params := &s3.ListObjectsV2Input{
 		Bucket:  aws.String(storage.bucket),
 		Prefix:  aws.String(prefix),
 		MaxKeys: aws.Int64(1000),
 	}
 
-	err = storage.s3.ListObjectsPages(params, func(contents *s3.ListObjectsOutput, lastPage bool) bool {
+	err = storage.s3.ListObjectsV2Pages(params, func(contents *s3.ListObjectsV2Output, lastPage bool) bool {
 		for _, key := range contents.Contents {
 			if storage.plusWorkaround && hidePlusWorkaround && strings.Contains(*key.Key, " ") {
 				// if we use plusWorkaround, we want to hide those duplicates


### PR DESCRIPTION
This is a copy of https://github.com/giuli007/aptly/pull/1 (based off a recent master and not including the changes in https://github.com/aptly-dev/aptly/pull/1002 so they can be merged separately) to be merged into the Yelp fork of aptly along with other changes so we can streamline changes to aptly from different contributors and build them internally.

Copied the relevant description for visibility

## Fixes


This change is to addresses a situation we have encountered running in AWS EKS where each single (1000-paginated) request using the older `ListObjects` API via `s3.ListObjectsPages` takes seconds to receive a response, resulting in tens of minutes long publishing times when the bucket contains >100k packages (which is the cases for repos mirrored from ubuntu repos and republished in-house).
This doesn't look like normal throttling as no explicit throttled responses are seen when enabling `debug` in the https://www.aptly.info/doc/configuration/. The reasons why the old API is so slow only when running in EKS are still unknown.


## Description of the Change

<!--

Why this change is important?

-->
Uses the more modern recommended `ListObjectsV2` to list objects on the S3 bucket when publishing to it.
https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html

This is faster, especially when running in EKS. 
